### PR TITLE
Fix tuple() to allow executing in any context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ function simpleFind(options)
  }
  ```
 
-## tuple(array,ordinal)
-This functions creates a tuples of ? or $1, $2 from a array of values depending on if the ordinal parameter is set or not.
+## tuple(array, makeOrdinal)
+This functions creates a tuples of ? or $1, $2 from a array of values depending on if the makeOrdinal parameter is set or not.
 
 ```
 const arr = [
@@ -52,9 +52,9 @@ const arr = [
 ```
 becomes
 ```
-(?,?,?) // ordinal = false
+(?,?,?) // makeOrdinal = false
 OR
-($1,$2,$3) // ordinal = true
+($1,$2,$3) // makeOrdinal = true
 ```
 
 This can be helpful if you want to create a insert statement

--- a/index.js
+++ b/index.js
@@ -21,15 +21,15 @@ const flatten = function(arr) {
     },[])
 }
 
-const tuple = function(arr, ordinal) {
+const tuple = function(arr, makeOrdinal) {
     const tuple = arr.map(function(item) {        
 	    return '(' + item.map(value => '?').join(',') +')';
     }).join(',');
     
-    if (!ordinal) {
+    if (!makeOrdinal) {
         return tuple;
     } else {                
-        return this.ordinal(tuple);        
+        return ordinal(tuple);        
     }
 }
 


### PR DESCRIPTION
tuple(..., true) can be executed only in the context of module, because of 'this', used in code. But sometimes it is useful to import module using destructive assignment:
```node
const { ordinal, tuple, flatten } = require('pg-parameterize');
let str = tuple([['a', 'b', 'c']], true);
``` 
But in this case i will receive an error:
```
TypeError: Cannot read property 'ordinal' of undefined
``` 
